### PR TITLE
Enable for languages other than Go

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
             }
         }
 
-        let dispose = vscode.languages.registerDocumentLinkProvider('go', provider);
+        let dispose = vscode.languages.registerDocumentLinkProvider('*', provider);
         context.subscriptions.push(dispose);
     }
     if (vscode.workspace.rootPath != undefined) {


### PR DESCRIPTION
Change language selector from `'go'` to `'*'`.