### PR TITLE
Fix transforming "owner/repo.git" to "owner/repo"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,9 +39,11 @@ export function activate(context: vscode.ExtensionContext) {
       fs.readFile(gconfig, 'utf-8', (err, data) => {
           if (err == null) {
           for (let line of data.split('\n')) {
-              let match = /\s*url\s*=.*github.com\/([^\/]+\/[^\/]+)(?:\.git|$)/.exec(line)
+              let match = /\s*url\s*=.*github.com\/([^\/]+\/[^\/]+)$/.exec(line)
               if (match) {
-                  let repo = match[1]
+                  let rawRepo = match[1]
+                  // Transform "dt/ghlink.git" into "dt/ghlink"
+                  let repo = rawRepo.endsWith('.git') ? rawRepo.substring(0, rawRepo.length - '.git'.length) : rawRepo
                   linkIssues(repo)
                   return
               }


### PR DESCRIPTION
Regexps in JS are eager, trying to capture `.git` at the end doesn't work
because the owner/repo group (`([^\/]+\/[^\/]+)`) captures it already.

Fix this by trimming ".git" from the end manually with `.substring`.