### PR TITLE
Allow period in repo names

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,14 +20,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
                 // @user/repo
                 {
-                    re: /@([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-]+)\b/g,
+                    re: /@([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-.]+)\b/g,
                     isEnabled: () => basename(document.fileName) !== 'package.json',
                     matchToUrl: match => `https://github.com/${match[1]}`
                 },
 
                 // #123 and user/repo#123
                 {
-                    re: /@?([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-]+)?#(\d+)\b/g,
+                    re: /@?([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-.]+)?#(\d+)\b/g,
                     isEnabled: () => true,
                     matchToUrl: match => (match[1] || currentRepo) ? `https://github.com/${match[1] || currentRepo}/issues/${match[2]}` : null
                 }


### PR DESCRIPTION
Periods are allowed in GitHub repo names but not considered by the extensions, therefore links to issues in repos like [nuxt/nuxt.js](https://github.com/nuxt/nuxt.js) won't currently work.

This PR adds the period as a valid character for repositories. 🙂