### PR TITLE
Link to commits with `user/repo:sha`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ Marks the following text in your files as links:
 - `user/repo#123` - links to the issue or PR
 - `#123` if `.git/config` includes a GitHub remote
 - `user/repo:a1b2` - links to individual commits (requires 4+ characters of SHA)
+- `user/repo@a1b2` - as above (to link github actions back to their repos)
 - `@user/repo` - links to the GitHub repo page

--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ Marks the following text in your files as links:
 
 - `user/repo#123` - links to the issue or PR
 - `#123` if `.git/config` includes a GitHub remote
+- `user/repo:a1b2` - links to individual commits (requires 4+ characters of SHA)
 - `@user/repo` - links to the GitHub repo page

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,9 +32,9 @@ export async function activate(context: vscode.ExtensionContext) {
                     matchToUrl: match => (match[1] || currentRepo) ? `https://github.com/${match[1] || currentRepo}/issues/${match[2]}` : null
                 },
 
-                // user/repo:sha
+                // user/repo:sha and user/repo@sha
                 {
-                    re: /@?([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-.]+):([0-9A-Fa-f]{4,})\b/g,
+                    re: /@?([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-.]+)[:@]([0-9A-Fa-f]{4,})\b/g,
                     isEnabled: () => true,
                     matchToUrl: match => match[1] ? `https://github.com/${match[1]}/commit/${match[2]}` : null
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,13 @@ export async function activate(context: vscode.ExtensionContext) {
                     re: /@?([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-.]+)?#(\d+)\b/g,
                     isEnabled: () => true,
                     matchToUrl: match => (match[1] || currentRepo) ? `https://github.com/${match[1] || currentRepo}/issues/${match[2]}` : null
+                },
+
+                // user/repo:sha
+                {
+                    re: /@?([a-zA-Z0-9_\-]+\/[a-zA-Z0-9_\-.]+):([0-9A-Fa-f]{4,})\b/g,
+                    isEnabled: () => true,
+                    matchToUrl: match => match[1] ? `https://github.com/${match[1]}/commit/${match[2]}` : null
                 }
             ]
 


### PR DESCRIPTION
Not sure if this is something you'd considered and ruled out for this extension, but I'm finding it personally useful.

The need for 4+ characters for the commit SHA seems to be a GitHub requirement.